### PR TITLE
Export inspected scope in angularScope global var

### DIFF
--- a/src/chrome/content/context_menu.js
+++ b/src/chrome/content/context_menu.js
@@ -4,6 +4,7 @@
         if (angular && Firebug) {
             var scope = angular.element(gContextMenu.target).scope();
             if (scope) {
+            	content.wrappedJSObject.angularScope = scope;
             	Firebug.browserOverlay.startFirebug(function() {
             		Firebug.toggleBar(true);
                	Firebug.chrome.select(scope, 'dom');	

--- a/src/chrome/content/context_menu.js
+++ b/src/chrome/content/context_menu.js
@@ -1,14 +1,16 @@
 ﻿var AngScopeFbModule = {
     inspectAngScope: function inspectAngScope() {
         var angular = content.wrappedJSObject.angular;
-        if (angular && Firebug) {
+        if (angular) {
             var scope = angular.element(gContextMenu.target).scope();
             if (scope) {
             	content.wrappedJSObject.angularScope = scope;
-            	Firebug.browserOverlay.startFirebug(function() {
-            		Firebug.toggleBar(true);
-               	Firebug.chrome.select(scope, 'dom');	
-            	});
+            	if (Firebug) {
+                Firebug.browserOverlay.startFirebug(function() {
+                  Firebug.toggleBar(true);
+                  Firebug.chrome.select(scope, 'dom');	
+                });
+              }
             }
         }
     }

--- a/src/chrome/content/context_menu.js
+++ b/src/chrome/content/context_menu.js
@@ -4,13 +4,13 @@
         if (angular) {
             var scope = angular.element(gContextMenu.target).scope();
             if (scope) {
-            	content.wrappedJSObject.angularScope = scope;
-            	if (Firebug) {
-                Firebug.browserOverlay.startFirebug(function() {
-                  Firebug.toggleBar(true);
-                  Firebug.chrome.select(scope, 'dom');	
-                });
-              }
+                content.wrappedJSObject.angularScope = scope;
+                if (Firebug) {
+                    Firebug.browserOverlay.startFirebug(function() {
+                        Firebug.toggleBar(true);
+                        Firebug.chrome.select(scope, 'dom');
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
> One missing feature, though, is to have a means of addressing that scope from within the console. This would allow interacting with that scope instead of just browsing it.

In some comments people ask feature for accessing the inspected scope (instead of simply displaying in the DOM page of FireBug tools), so i decided to save in the `angularScope` global variable, accessible from the console.
